### PR TITLE
Update typesystem_shiboken.xml

### DIFF
--- a/shibokenmodule/typesystem_shiboken.xml
+++ b/shibokenmodule/typesystem_shiboken.xml
@@ -17,7 +17,7 @@
         </inject-code>
     </add-function>
 
-    <add-function signature="wrapInstance(unsigned long, PyType)" return-type="PyObject*">
+    <add-function signature="wrapInstance(size_t, PyType)" return-type="PyObject*">
         <inject-code>
             if (Shiboken::ObjectType::checkType((PyTypeObject*)%2))
                 %PYARG_0 = Shiboken::Object::newObject((SbkObjectType*)%2, (void*)%1, false, true);


### PR DESCRIPTION
When trying to create windows with wrapInstance on 64bit windows, the widget handle could be beyond an unsigned long and crash pyside.