### PR TITLE
Fix missing dependency to QtCore in tests.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+find_package(Qt5 REQUIRED COMPONENTS Core)
+include_directories(${Qt5Core_INCLUDE_DIRS})
+
 add_subdirectory(libminimal)
 if(NOT DEFINED MINIMAL_TESTS)
     add_subdirectory(libsample)


### PR DESCRIPTION
QtCore is required because QDebug is now included by default in wrappers