### PR TITLE
Fix running the shiboken generator during build on Visual Studio

### DIFF
--- a/shibokenmodule/CMakeLists.txt
+++ b/shibokenmodule/CMakeLists.txt
@@ -9,7 +9,7 @@ ${CMAKE_CURRENT_BINARY_DIR}/shiboken/shiboken_module_wrapper.cpp
 )
 
 add_custom_command(OUTPUT ${sample_SRC}
-COMMAND ${shibokengenerator_BINARY_DIR}/shiboken2 --project-file=${CMAKE_CURRENT_BINARY_DIR}/shibokenmodule.txt ${GENERATOR_EXTRA_FLAGS}
+COMMAND shiboken2 --project-file=${CMAKE_CURRENT_BINARY_DIR}/shibokenmodule.txt ${GENERATOR_EXTRA_FLAGS}
 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 COMMENT "Running generator for 'shiboken2'..."
 )


### PR DESCRIPTION
On Windows, when using Visual Studio, there is an additional "Debug" or "Release" directory under the
`<project_name>_BINARY_DIR` path so running the generator would sometimes fail.

In later versions of CMake, we can pass the executable target's name directly to `add_custom_command` and it will use the correct path.