### PR TITLE
Name of shiboken Python package is inconsistent.

### DIFF
--- a/shibokenmodule/CMakeLists.txt
+++ b/shibokenmodule/CMakeLists.txt
@@ -5,7 +5,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/shibokenmodule.txt.in"
 
 
 set(sample_SRC
-${CMAKE_CURRENT_BINARY_DIR}/shiboken/shiboken_module_wrapper.cpp
+${CMAKE_CURRENT_BINARY_DIR}/shiboken2/shiboken2_module_wrapper.cpp
 )
 
 add_custom_command(OUTPUT ${sample_SRC}

--- a/shibokenmodule/typesystem_shiboken.xml
+++ b/shibokenmodule/typesystem_shiboken.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<typesystem package="shiboken">
+<typesystem package="shiboken2">
     <custom-type name="PyObject" />
     <custom-type name="PyType" />
     <primitive-type name="bool" />

--- a/tests/otherbinding/objtypehashes_test.py
+++ b/tests/otherbinding/objtypehashes_test.py
@@ -1,7 +1,7 @@
 import unittest
 from sample import *
 from other import *
-import shiboken
+import shiboken2 as shiboken
 
 class TestHashFuncs (unittest.TestCase):
 

--- a/tests/samplebinding/delete_test.py
+++ b/tests/samplebinding/delete_test.py
@@ -26,7 +26,7 @@
 
 import unittest
 import sample
-import shiboken
+import shiboken2 as shiboken
 
 class DeleteTest(unittest.TestCase):
     def testNonCppWrapperClassDelete(self):

--- a/tests/samplebinding/objecttype_test.py
+++ b/tests/samplebinding/objecttype_test.py
@@ -30,7 +30,7 @@ import unittest
 import sys
 
 from sample import ObjectType, Str
-import shiboken
+import shiboken2 as shiboken
 
 
 class ObjectTypeTest(unittest.TestCase):

--- a/tests/samplebinding/privatedtor_test.py
+++ b/tests/samplebinding/privatedtor_test.py
@@ -30,7 +30,7 @@ import gc
 import sys
 import unittest
 
-import shiboken
+import shiboken2 as shiboken
 from sample import PrivateDtor
 
 

--- a/tests/shibokenmodule/module_test.py
+++ b/tests/shibokenmodule/module_test.py
@@ -1,4 +1,4 @@
-import shiboken
+import shiboken2 as shiboken
 import unittest
 from sample import *
 


### PR DESCRIPTION
Is the Python package is intended to be called `shiboken2` instead of `shiboken`? That is the TARGET name in `./shibokenmodule/CMakeLists.txt`; this PR consistently uses the new name.

All tests now run without failure.