### PR TITLE
Fix the metatype parser handling of pointer template parameters

### DIFF
--- a/generator/shiboken2/shibokengenerator.cpp
+++ b/generator/shiboken2/shibokengenerator.cpp
@@ -2083,14 +2083,15 @@ AbstractMetaType* ShibokenGenerator::buildAbstractMetaTypeFromString(QString typ
     if (isConst)
         typeString.remove(0, sizeof("const ") / sizeof(char) - 1);
 
-    int indirections = typeString.count("*");
-    while (typeString.endsWith("*")) {
+    bool isReference = typeString.endsWith("&");
+    if (isReference) {
         typeString.chop(1);
         typeString = typeString.trimmed();
     }
 
-    bool isReference = typeString.endsWith("&");
-    if (isReference) {
+    int indirections = 0;
+    while (typeString.endsWith("*")) {
+        ++indirections;
         typeString.chop(1);
         typeString = typeString.trimmed();
     }

--- a/tests/libsample/CMakeLists.txt
+++ b/tests/libsample/CMakeLists.txt
@@ -43,6 +43,7 @@ size.cpp
 sometime.cpp
 str.cpp
 strlist.cpp
+templateptr.cpp
 transform.cpp
 virtualmethods.cpp
 expression.cpp

--- a/tests/libsample/templateptr.cpp
+++ b/tests/libsample/templateptr.cpp
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Shiboken Python Binding Generator project.
+ *
+ * Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+ *
+ * Contact: PySide team <contact@pyside.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "templateptr.h"
+
+void TemplatePtr::dummy(std::list<std::pair<BlackBox *, BlackBox *> > & items)
+{
+}

--- a/tests/libsample/templateptr.h
+++ b/tests/libsample/templateptr.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Shiboken Python Binding Generator project.
+ *
+ * Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+ *
+ * Contact: PySide team <contact@pyside.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef TEMPLATEPTR_H
+#define TEMPLATEPTR_H
+
+#include <utility>
+#include <list>
+#include "libsamplemacros.h"
+#include "BlackBox.h"
+
+class LIBSAMPLE_API TemplatePtr
+{
+public:
+	void dummy(std::list<std::pair<BlackBox *, BlackBox *> > & items);
+};
+
+#endif

--- a/tests/samplebinding/CMakeLists.txt
+++ b/tests/samplebinding/CMakeLists.txt
@@ -105,6 +105,7 @@ ${CMAKE_CURRENT_BINARY_DIR}/sample/sonofmderived1_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/str_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/strlist_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/time_wrapper.cpp
+${CMAKE_CURRENT_BINARY_DIR}/sample/templateptr_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/unremovednamespace_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/virtualdaughter_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/virtualdtor_wrapper.cpp

--- a/tests/samplebinding/global.h
+++ b/tests/samplebinding/global.h
@@ -54,6 +54,7 @@
 #include "str.h"
 #include "strlist.h"
 #include "sometime.h"
+#include "templateptr.h"
 #include "transform.h"
 #include "virtualmethods.h"
 #include "voidholder.h"

--- a/tests/samplebinding/typesystem_sample.xml
+++ b/tests/samplebinding/typesystem_sample.xml
@@ -2395,6 +2395,10 @@
     <value-type name="ValueAndVirtual" />
 
     <object-type name="ObjectTypeByValue" />
+    
+    <object-type name="TemplatePtr">
+        <modify-function signature="dummy(std::list&lt;std::pair&lt;BlackBox *, BlackBox *&gt; &gt; &amp;)" rename="dummy_method" />
+    </object-type>
 
     <suppress-warning text="horribly broken type '__off64_t'" />
     <suppress-warning text="enum '__codecvt_result' does not have a type entry or is not an enum" />


### PR DESCRIPTION
- References can exist only at the end of a type declaration (i.e. T &, T * & and even T * * &, but never T & *), so we can parse them before pointers to simplify things.
- Pointers need to be considered only at the end of the type, else we're going to do the wrong thing for types like C<T1 *, T2 *>.

As far as I can tell, these changes don't trigger any new test failures.