### PR TITLE
Change include from "BlackBox.h" (do not exists) to "blackbox.h"

### DIFF
--- a/tests/libsample/templateptr.h
+++ b/tests/libsample/templateptr.h
@@ -26,7 +26,7 @@
 #include <utility>
 #include <list>
 #include "libsamplemacros.h"
-#include "BlackBox.h"
+#include "blackbox.h"
 
 class LIBSAMPLE_API TemplatePtr
 {


### PR DESCRIPTION
I don't know why this bug is still here but I think this bug can pass silently in these cases: 
  - users do not build test libraries (with cmake option -DBUILD_TESTS=OFF)
  - users/developers have shiboken sources on a fat32 partition (for example an usb hard disk, old windows, partition shared between win and linux, ...). In this case, system may not see differences between upper and lower case. 

As file is on git and do not change, it is not a generated file.
I cannot say more about it.