### PR TITLE
Fix GCC 5 warning: logical not is only applied to the left hand side …

### DIFF
--- a/tests/libsample/oddbool.h
+++ b/tests/libsample/oddbool.h
@@ -38,12 +38,12 @@ private:
     bool m_value;
 };
 
-inline bool operator==(OddBool b1, bool b2) { return !b1 == !b2; }
-inline bool operator==(bool b1, OddBool b2) { return !b1 == !b2; }
-inline bool operator==(OddBool b1, OddBool b2) { return !b1 == !b2; }
-inline bool operator!=(OddBool b1, bool b2) { return !b1 != !b2; }
-inline bool operator!=(bool b1, OddBool b2) { return !b1 != !b2; }
-inline bool operator!=(OddBool b1, OddBool b2) { return !b1 != !b2; }
+inline bool operator==(OddBool b1, bool b2) { return (!b1) == !b2; }
+inline bool operator==(bool b1, OddBool b2) { return (!b1) == !b2; }
+inline bool operator==(OddBool b1, OddBool b2) { return (!b1) == !b2; }
+inline bool operator!=(OddBool b1, bool b2) { return (!b1) != !b2; }
+inline bool operator!=(bool b1, OddBool b2) { return (!b1) != !b2; }
+inline bool operator!=(OddBool b1, OddBool b2) { return (!b1) != !b2; }
 
 class OddBoolUser
 {


### PR DESCRIPTION
…of comparison [-Wlogical-not-parentheses]

Fix for libsample.