### PR TITLE
Fix #36

### DIFF
--- a/generator/shiboken2/cppgenerator.cpp
+++ b/generator/shiboken2/cppgenerator.cpp
@@ -394,6 +394,8 @@ void CppGenerator::generateClass(QTextStream &s, const AbstractMetaClass *metaCl
         foreach (const AbstractMetaField* metaField, metaClass->fields()) {
             if (metaField->isStatic())
                 continue;
+            if(metaField->enclosingClass()->isNamespace())
+                continue;
             writeGetterFunction(s, metaField);
             if (!metaField->type()->isConstant())
                 writeSetterFunction(s, metaField);
@@ -404,6 +406,8 @@ void CppGenerator::generateClass(QTextStream &s, const AbstractMetaClass *metaCl
         s << "static PyGetSetDef " << cpythonGettersSettersDefinitionName(metaClass) << "[] = {" << endl;
         foreach (const AbstractMetaField* metaField, metaClass->fields()) {
             if (metaField->isStatic())
+                continue;
+            if (metaField->enclosingClass()->isNamespace())
                 continue;
 
             bool hasSetter = !metaField->type()->isConstant();

--- a/tests/libsample/constants.h
+++ b/tests/libsample/constants.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Shiboken2 Python Binding Generator project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+static const double GLOBAL_CONSTANT = 1.23;
+
+namespace NamespaceConstant {
+  static const double NAMESPACE_CONSTANT = 4.56;
+}
+
+#endif // CONSTANTS_H

--- a/tests/samplebinding/CMakeLists.txt
+++ b/tests/samplebinding/CMakeLists.txt
@@ -46,6 +46,7 @@ ${CMAKE_CURRENT_BINARY_DIR}/sample/mderived5_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/modelindex_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/modifications_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/modifiedconstructor_wrapper.cpp
+${CMAKE_CURRENT_BINARY_DIR}/sample/namespaceconstant_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/noimplicitconversion_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/nondefaultctor_wrapper.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/sample/objectmodel_wrapper.cpp

--- a/tests/samplebinding/constant_test.py
+++ b/tests/samplebinding/constant_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of the Shiboken2 Python Bindings Generator project.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# version 2.1 as published by the Free Software Foundation. Please
+# review the following information to ensure the GNU Lesser General
+# Public License version 2.1 requirements will be met:
+# http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+# #
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA
+
+"""Unit test for bug shiboken2: https://github.com/PySide/shiboken2/issues/36 - shiboken1: https://bugreports.qt.io/browse/PYSIDE-186"""
+
+import unittest
+from sample import NamespaceConstant
+
+
+class ConstantTest(unittest.TestCase):
+    '''Test case for Derived class'''
+
+    def testConstants(self):
+        '''Test if Derived class really inherits its methods from parent.'''
+        self.assertTrue(isinstance(NamespaceConstant.NAMESPACE_CONSTANT, float))
+        self.assertEqual(str(NamespaceConstant.NAMESPACE_CONSTANT), '4.56')
+
+        # Does not work yet
+        #self.assertTrue(isinstance(GLOBAL_CONSTANT, float))
+        #self.assertEqual(str(GLOBAL_CONSTANT), '1.23')        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/samplebinding/global.h
+++ b/tests/samplebinding/global.h
@@ -10,6 +10,7 @@
 #include "derived.h"
 #include "echo.h"
 #include "functions.h"
+#include "constants.h"
 #include "implicitconv.h"
 #include "overloadsort.h"
 #include "handle.h"

--- a/tests/samplebinding/typesystem_sample.xml
+++ b/tests/samplebinding/typesystem_sample.xml
@@ -2400,6 +2400,9 @@
         <modify-function signature="dummy(std::list&lt;std::pair&lt;BlackBox *, BlackBox *&gt; &gt; &amp;)" rename="dummy_method" />
     </object-type>
 
+    <!-- check BUG: shiboken2: https://github.com/PySide/shiboken2/issues/36 - shiboken1: https://bugreports.qt.io/browse/PYSIDE-186 -->
+    <namespace-type name="NamespaceConstant" generate="yes" />
+
     <suppress-warning text="horribly broken type '__off64_t'" />
     <suppress-warning text="enum '__codecvt_result' does not have a type entry or is not an enum" />
     <suppress-warning text="Pure virtual method &quot;Abstract::hideFunction(HideType*)&quot; must be implement but was completely removed on typesystem." />


### PR DESCRIPTION
If a constant was defined at top level (directly in namespace for instance), shiboken tried to generate it as a class attribute that generate build error.
This patch detect if parent MetaClass is a namespace.
If it is the case, shiboken do not generate a class attribute using writeGetterFunction but generate a module attribute using existing code defined in writeClassRegister.
See "Write static fields" block.

WARNING: global constant not defined in a namespace doesn't work yet (constant wrapper is not generated but doesn't fail)
